### PR TITLE
sample keri code, use at your own risk

### DIFF
--- a/sample/keri/acdc/endorsement.rs
+++ b/sample/keri/acdc/endorsement.rs
@@ -1,0 +1,32 @@
+use crate::error::Result;
+use cesride::{counter, data::dat, Counter, Indexer, Matter, Pather, Seqner, Siger};
+
+pub(crate) fn ratify_creder(
+    prefix: &str,
+    seqner: Seqner,
+    said: &str,
+    sigers: &[Siger],
+) -> Result<String> {
+    let sad_path_sig = Counter::new_with_code_and_count(counter::Codex::SadPathSig, 1)?;
+    let path = dat!([]);
+    let pather = Pather::new_with_path(&path)?;
+
+    let mut proof = "".to_string();
+    proof += &sad_path_sig.qb64()?;
+    proof += &pather.qb64()?;
+
+    let counter = Counter::new_with_code_and_count(counter::Codex::TransIdxSigGroups, 1)?;
+    proof += &counter.qb64()?;
+    proof += prefix;
+    proof += &seqner.qb64()?;
+    proof += said;
+
+    let counter =
+        Counter::new_with_code_and_count(counter::Codex::ControllerIdxSigs, sigers.len() as u32)?;
+    proof += &counter.qb64()?;
+    for siger in sigers {
+        proof += &siger.qb64()?;
+    }
+
+    Ok(proof)
+}

--- a/sample/keri/acdc/event.rs
+++ b/sample/keri/acdc/event.rs
@@ -1,0 +1,90 @@
+use crate::error::Result;
+use cesride::{
+    common::{versify, Identage, Ids, Serialage, Tierage, Version, CURRENT_VERSION},
+    data::{dat, Value},
+    Creder, Matter, Saider, Salter,
+};
+
+#[allow(dead_code)]
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn create(
+    schema: &str,
+    issuer: &str,
+    data: &Value,
+    recipient: Option<&str>,
+    private: Option<bool>,
+    salt: Option<&str>,
+    status: Option<&str>,
+    source: Option<&Value>,
+    rules: Option<&Value>,
+    version: Option<&Version>,
+    kind: Option<&str>,
+) -> Result<Creder> {
+    let private = private.unwrap_or(false);
+    let version = version.unwrap_or(CURRENT_VERSION);
+    let kind = kind.unwrap_or(Serialage::JSON);
+
+    let vs = versify(Some(Identage::ACDC), Some(version), Some(kind), Some(0))?;
+
+    let mut vc = dat!({
+        "v": &vs,
+        "d": ""
+    });
+
+    let mut subject = dat!({
+        "d": ""
+    });
+
+    if private {
+        vc["u"] = if let Some(salt) = salt {
+            dat!(salt)
+        } else {
+            dat!(&Salter::new_with_defaults(Some(Tierage::low))?.qb64()?)
+        };
+
+        subject["u"] = if let Some(salt) = salt {
+            dat!(salt)
+        } else {
+            dat!(&Salter::new_with_defaults(Some(Tierage::low))?.qb64()?)
+        };
+    }
+
+    if let Some(recipient) = recipient {
+        subject["i"] = dat!(recipient);
+    }
+
+    let data_map = data.to_map()?;
+    subject["dt"] = if data_map.contains_key("dt") {
+        data_map["dt"].clone()
+    } else {
+        dat!(&chrono::Utc::now().format("%+").to_string())
+    };
+
+    for (label, value) in data_map {
+        subject[label.as_str()] = value
+    }
+
+    vc[Ids::i] = dat!(issuer);
+
+    if let Some(status) = status {
+        vc["ri"] = dat!(status);
+    }
+
+    vc["s"] = dat!(schema);
+    vc["a"] = dat!({});
+
+    if let Some(source) = source {
+        vc["e"] = source.clone();
+    }
+
+    if let Some(rules) = rules {
+        vc["r"] = rules.clone();
+    }
+
+    let (_, sad) = Saider::saidify(&subject, None, Some(kind), Some(Ids::d), None)?;
+    vc["a"] = sad;
+
+    let (_, vc) = Saider::saidify(&vc, None, None, None, None)?;
+
+    Creder::new_with_ked(&vc, None, None)
+}

--- a/sample/keri/acdc/message.rs
+++ b/sample/keri/acdc/message.rs
@@ -1,0 +1,18 @@
+use crate::error::{err, Error, Result};
+use cesride::{counter, Counter, Creder, Sadder};
+
+pub(crate) fn messagize_creder(creder: &Creder, proof: &str) -> Result<String> {
+    let mut message = String::from_utf8(creder.raw())?;
+    if proof.len() % 4 != 0 {
+        return err!(Error::Value);
+    }
+
+    message += &Counter::new_with_code_and_count(
+        counter::Codex::AttachedMaterialQuadlets,
+        proof.len() as u32 / 4,
+    )?
+    .qb64()?;
+    message += proof;
+
+    Ok(message)
+}

--- a/sample/keri/acdc/mod.rs
+++ b/sample/keri/acdc/mod.rs
@@ -114,8 +114,8 @@ pub fn issue_acdc(
         "d": &iss_said,
     }]);
     let key_set = store.get_current_keys(issuer)?;
-    for verfer in &key_set.verfers()? {
-        k.push(dat!(&verfer.qb64()?));
+    for qb64 in &key_set.verfers_qb64()? {
+        k.push(dat!(qb64));
     }
     sigers.append(&mut key_set.sign(&acdc.raw(), None)?);
     let (ixn_said, ixn) = super::kmi::interact(&key_set, issuer, &dig, sn, &data)?;

--- a/sample/keri/acdc/mod.rs
+++ b/sample/keri/acdc/mod.rs
@@ -1,0 +1,166 @@
+pub(crate) mod endorsement;
+pub(crate) mod event;
+pub(crate) mod message;
+pub(crate) mod schemer;
+pub(crate) mod tel;
+pub(crate) mod verification;
+
+use super::KeriStore;
+use crate::error::{err, Error, Result};
+use cesride::{
+    counter,
+    data::{dat, Value},
+    Counter, Matter, Sadder, Seqner, Serder,
+};
+
+#[allow(clippy::too_many_arguments)]
+pub fn issue_acdc(
+    store: &impl KeriStore,
+    status: &str, // public management tel registry identifier
+    issuer: &str, // controlled identifier label
+    schema: &str,
+    data: &str,
+    recipient: Option<&str>,
+    private: Option<bool>,
+    source: Option<&str>,
+    rules: Option<&str>,
+) -> Result<(String, String, String, String)> {
+    let value: serde_json::Value = serde_json::from_str(data)?;
+    let data = Value::from(&value);
+
+    let acdc = if source.is_some() && rules.is_some() {
+        let value: serde_json::Value = serde_json::from_str(source.unwrap())?;
+        let source = Value::from(&value);
+        let source = Some(&source);
+        let value: serde_json::Value = serde_json::from_str(rules.unwrap())?;
+        let rules = Value::from(&value);
+        let rules = Some(&rules);
+        event::create(
+            schema,
+            issuer,
+            &data,
+            recipient,
+            private,
+            None,
+            Some(status),
+            source,
+            rules,
+            None,
+            None,
+        )?
+    } else if source.is_some() {
+        let value: serde_json::Value = serde_json::from_str(source.unwrap())?;
+        let source = Value::from(&value);
+        let source = Some(&source);
+        event::create(
+            schema,
+            issuer,
+            &data,
+            recipient,
+            private,
+            None,
+            Some(status),
+            source,
+            None,
+            None,
+            None,
+        )?
+    } else if rules.is_some() {
+        let value: serde_json::Value = serde_json::from_str(rules.unwrap())?;
+        let rules = Value::from(&value);
+        let rules = Some(&rules);
+        event::create(
+            schema,
+            issuer,
+            &data,
+            recipient,
+            private,
+            None,
+            Some(status),
+            None,
+            rules,
+            None,
+            None,
+        )?
+    } else {
+        event::create(
+            schema,
+            issuer,
+            &data,
+            recipient,
+            private,
+            None,
+            Some(status),
+            None,
+            None,
+            None,
+            None,
+        )?
+    };
+
+    // println!("{}", std::str::from_utf8(&acdc.raw())?);
+
+    let mut sigers = vec![];
+    let mut k: Vec<Value> = vec![];
+
+    let acdc_said = acdc.said()?;
+    let (iss_said, iss) = tel::vc::issue(&acdc_said, status)?;
+
+    let sn = store.count_key_events(issuer)? as u128;
+    let dig = store.get_latest_key_event_said(issuer)?;
+    let data = dat!([{
+        "i": &acdc_said,
+        "s": "0",
+        "d": &iss_said,
+    }]);
+    let key_set = store.get_current_keys(issuer)?;
+    for verfer in &key_set.verfers()? {
+        k.push(dat!(&verfer.qb64()?));
+    }
+    sigers.append(&mut key_set.sign(&acdc.raw(), None)?);
+    let (ixn_said, ixn) = super::kmi::interact(&key_set, issuer, &dig, sn, &data)?;
+    drop(key_set);
+
+    let counter = Counter::new_with_code_and_count(counter::Codex::SealSourceCouples, 1)?;
+    let seqner = Seqner::new_with_sn(sn)?;
+    let iss = iss + &counter.qb64()? + &seqner.qb64()? + &ixn_said;
+
+    let (said, sn) = store.get_latest_establishment_event_said(issuer)?;
+    let seqner = Seqner::new_with_sn(sn)?;
+    let proof = endorsement::ratify_creder(issuer, seqner, &said, &sigers)?;
+    let signed_acdc = message::messagize_creder(&acdc, &proof)?;
+
+    Ok((acdc_said, ixn, iss, signed_acdc))
+}
+
+pub fn revoke_acdc(
+    store: &impl KeriStore,
+    status: &str,
+    issuer: &str,
+    said: &str,
+) -> Result<(String, String)> {
+    let priors = store.get_tel(said)?;
+    if priors.len() != 1 {
+        return err!(Error::Value);
+    }
+    let serder = Serder::new_with_raw(priors[0].as_bytes())?;
+
+    let (rev_said, rev) = tel::vc::revoke(said, status, &serder.said()?)?;
+
+    let sn = store.count_key_events(issuer)? as u128;
+    let dig = store.get_latest_key_event_said(issuer)?;
+    let data = dat!([{
+        "i": said,
+        "s": "1",
+        "d": &rev_said,
+    }]);
+    let key_set = store.get_current_keys(issuer)?;
+    let (ixn_said, ixn) = super::kmi::interact(&key_set, issuer, &dig, sn, &data)?;
+    drop(key_set);
+
+    let counter = Counter::new_with_code_and_count(counter::Codex::SealSourceCouples, 1)?;
+    let seqner = Seqner::new_with_sn(sn)?;
+    let rev = rev + &counter.qb64()? + &seqner.qb64()? + &ixn_said;
+
+    Ok((ixn, rev))
+}

--- a/sample/keri/acdc/schemer.rs
+++ b/sample/keri/acdc/schemer.rs
@@ -1,0 +1,405 @@
+use std::collections::HashMap;
+
+use boon::{Compiler, SchemaIndex, Schemas};
+use cesride::{
+    common::{Ids, Serialage},
+    dat,
+    data::Value,
+    matter, Matter, Saider,
+};
+use parking_lot::{RwLock, RwLockReadGuard, RwLockWriteGuard};
+
+use crate::error::{err, Error, Result};
+
+struct SchemaCache {
+    resolver: RwLock<Schemas>,
+    map: RwLock<HashMap<String, SchemaIndex>>,
+}
+
+impl SchemaCache {
+    fn resolver(&self) -> RwLockReadGuard<Schemas> {
+        self.resolver.read()
+    }
+
+    fn resolver_mut(&mut self) -> RwLockWriteGuard<Schemas> {
+        self.resolver.write()
+    }
+
+    fn map(&self) -> RwLockReadGuard<HashMap<String, SchemaIndex>> {
+        self.map.read()
+    }
+
+    fn map_mut(&self) -> RwLockWriteGuard<HashMap<String, SchemaIndex>> {
+        self.map.write()
+    }
+
+    pub(crate) fn add(&mut self, key: &str, schema: &str, sed: &Value) -> Result<()> {
+        if self.map().contains_key(&key.to_string()) {
+            return Ok(());
+        }
+
+        let saider = Saider::new_with_qb64(key)?;
+        if !saider.verify(
+            sed,
+            Some(false),
+            Some(false),
+            Some(Serialage::JSON),
+            Some(Ids::dollar),
+            None,
+        )? {
+            return err!(Error::Verification);
+        }
+
+        let mut compiler = Compiler::new();
+        let value: serde_json::Value = serde_json::from_str(schema)?;
+        match compiler.add_resource(key, value) {
+            Ok(_) => (),
+            Err(_) => return err!(Error::Value),
+        };
+
+        let index = match compiler.compile(key, &mut self.resolver_mut()) {
+            Ok(index) => index,
+            Err(_) => return err!(Error::Value),
+        };
+
+        self.map_mut().insert(key.to_string(), index);
+
+        Ok(())
+    }
+
+    pub(crate) fn validate(&mut self, uri: &str, instance: &str) -> Result<bool> {
+        let map = self.map();
+        let loc = map.get(&uri.to_string());
+        if let Some(loc) = loc {
+            let value: serde_json::Value = serde_json::from_str(instance)?;
+            match self.resolver().validate(&value, *loc) {
+                Ok(()) => Ok(true),
+                Err(_) => Ok(false),
+            }
+        } else {
+            Ok(false)
+        }
+    }
+}
+
+fn schema_cache() -> &'static mut SchemaCache {
+    static mut CACHE: std::mem::MaybeUninit<SchemaCache> = std::mem::MaybeUninit::uninit();
+    static ONCE: std::sync::Once = std::sync::Once::new();
+
+    unsafe {
+        ONCE.call_once(|| {
+            let cache = SchemaCache {
+                resolver: RwLock::new(Schemas::new()),
+                map: RwLock::new(HashMap::new()),
+            };
+            CACHE.write(cache);
+        });
+
+        CACHE.assume_init_mut()
+    }
+}
+
+#[allow(dead_code)]
+pub(crate) struct SchemerCache {
+    map: RwLock<HashMap<String, Schemer>>,
+}
+
+#[allow(dead_code)]
+impl SchemerCache {
+    fn map(&self) -> RwLockReadGuard<HashMap<String, Schemer>> {
+        self.map.read()
+    }
+
+    fn map_mut(&self) -> RwLockWriteGuard<HashMap<String, Schemer>> {
+        self.map.write()
+    }
+
+    pub fn prime(&self, schemers: &[Schemer]) -> Result<()> {
+        for schemer in schemers {
+            self.map_mut().insert(schemer.said()?, schemer.clone());
+        }
+
+        Ok(())
+    }
+
+    pub fn get(&self, said: &str) -> Result<Schemer> {
+        Ok(self.map()[&said.to_string()].clone())
+    }
+
+    pub fn verify(&self, said: &str, json: &str) -> Result<bool> {
+        self.map()[&said.to_string()].verify(json.as_bytes())
+    }
+}
+
+#[allow(dead_code)]
+pub(crate) fn cache() -> &'static mut SchemerCache {
+    static mut CACHE: std::mem::MaybeUninit<SchemerCache> = std::mem::MaybeUninit::uninit();
+    static ONCE: std::sync::Once = std::sync::Once::new();
+
+    unsafe {
+        ONCE.call_once(|| {
+            let cache = SchemerCache { map: RwLock::new(HashMap::new()) };
+            CACHE.write(cache);
+        });
+
+        CACHE.assume_init_mut()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct Schemer {
+    raw: Vec<u8>,
+    sed: Value,
+    kind: String,
+    saider: Saider,
+}
+
+#[allow(dead_code)]
+impl Schemer {
+    pub fn new(
+        raw: Option<&[u8]>,
+        sed: Option<&Value>,
+        kind: Option<&str>,
+        code: Option<&str>,
+    ) -> Result<Self> {
+        let code = code.unwrap_or(matter::Codex::Blake3_256);
+
+        let (raw, sed, kind, saider) = if let Some(raw) = raw {
+            let (sed, kind, saider) = Self::inhale(raw)?;
+            (raw.to_vec(), sed, kind, saider)
+        } else if let Some(sed) = sed {
+            Self::exhale(sed, code, kind)?
+        } else {
+            return err!(Error::Value);
+        };
+
+        schema_cache().add(&saider.qb64()?, std::str::from_utf8(&raw)?, &sed)?;
+
+        Ok(Schemer { raw, sed, kind, saider })
+    }
+
+    fn inhale(raw: &[u8]) -> Result<(Value, String, Saider)> {
+        let value: serde_json::Value = serde_json::from_slice(raw)?;
+        let sed = Value::from(&value);
+
+        let map = sed.to_map()?;
+        let label = &Ids::dollar.to_string();
+        let saider = if map.contains_key(label) {
+            let said = map[label].to_string()?;
+            let saider = Saider::new_with_qb64(&said)?;
+            if !saider.verify(&sed, Some(true), None, Some(Serialage::JSON), Some(label), None)? {
+                return err!(Error::Validation);
+            }
+
+            saider
+        } else {
+            return err!(Error::Validation);
+        };
+
+        Ok((sed, Serialage::JSON.to_string(), saider))
+    }
+
+    fn exhale(
+        sed: &Value,
+        code: &str,
+        kind: Option<&str>,
+    ) -> Result<(Vec<u8>, Value, String, Saider)> {
+        let kind = kind.unwrap_or(Serialage::JSON);
+        if kind != Serialage::JSON {
+            return err!(Error::Value);
+        }
+
+        let label = &Ids::dollar.to_string();
+        let saider =
+            Saider::new(Some(sed), Some(label), None, None, Some(code), None, None, None, None)?;
+        let mut sed = sed.clone();
+        sed["$id"] = dat!(&saider.qb64()?);
+        let raw = sed.to_json()?.as_bytes().to_vec();
+
+        Ok((raw, sed, kind.to_string(), saider))
+    }
+
+    pub(crate) fn raw(&self) -> Vec<u8> {
+        self.raw.clone()
+    }
+
+    pub(crate) fn sed(&self) -> Value {
+        self.sed.clone()
+    }
+
+    pub(crate) fn kind(&self) -> String {
+        self.kind.clone()
+    }
+
+    pub(crate) fn said(&self) -> Result<String> {
+        self.saider.qb64()
+    }
+
+    pub(crate) fn saider(&self) -> Saider {
+        self.saider.clone()
+    }
+
+    pub(crate) fn verify(&self, raw: &[u8]) -> Result<bool> {
+        schema_cache().validate(&self.said()?, std::str::from_utf8(raw)?)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::{cache, Schemer};
+    use cesride::data::dat;
+
+    #[test]
+    fn schemas() {
+        let mut schemers = vec![];
+
+        let sed = dat!({
+            "$id": "", //
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "title": "Example Block",
+            "description": "An example block",
+            "credentialType": "ExampleBlockACDCAttributes",
+            "type": "object",
+            "required": [
+              "d",
+              "i",
+            ],
+            "properties": {
+              "d": {
+                "description": "Attributes SAID",
+                "type": "string"
+              },
+              "i": {
+                "description": "Issuee (Holder) AID",
+                "type": "string"
+              },
+            },
+            "additionalProperties": false
+        });
+
+        schemers.push(Schemer::new(None, Some(&sed), None, None).unwrap());
+
+        cache().prime(&schemers).unwrap();
+
+        assert!(cache()
+            .verify(&schemers[0].said().unwrap(), "{\"d\":\"foo\",\"i\":\"bar\"}")
+            .unwrap());
+        assert!(!cache().verify(&schemers[0].said().unwrap(), "{\"i\":\"bar\"}").unwrap());
+        assert!(!cache().verify(&schemers[0].said().unwrap(), "{\"d\":\"foo\"}").unwrap());
+        assert!(!cache()
+            .verify(&schemers[0].said().unwrap(), "{\"d\":\"foo\",\"i\":\"bar\",\"j\":\"baz\"}")
+            .unwrap());
+
+        let sed = dat!({
+            "$id": "ELT1L3PG16r4RIloH_nDw_1O432xHrAW1oaH3NTbDQwu",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "title": "Role Block",
+            "description": "A position held by a user",
+            "credentialType": "RoleBlockACDCAttributes",
+            "type": "object",
+            "required": [
+                "d",
+                "i",
+                "holders",
+                "supportingURL",
+                "logo",
+                "position",
+                "organizationName",
+                "status",
+                "startDate"
+            ],
+            "properties": {
+                "d": {
+                    "description": "Attributes SAID",
+                    "type": "string"
+                },
+                "i": {
+                    "description": "Issuee (Holder) AID",
+                    "type": "string"
+                },
+                "holders": {
+                    "description": "AIDs of all holders of this block",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "shortDescription": {
+                    "description": "A brief description of the block",
+                    "type": "string"
+                },
+                "longDescription": {
+                    "description": "A more detailed description of the block",
+                    "type": "string"
+                },
+                "headerTitle": {
+                    "description": "The title of the header for the block",
+                    "type": "string"
+                },
+                "headerImage": {
+                    "description": "The URL of the image associated with the header",
+                    "type": "string"
+                },
+                "supportingURL": {
+                    "description": "A URL that provides additional information on the role",
+                    "type": "string"
+                },
+                "logo": {
+                    "description": "The URL of the logo of the organization associated with the block",
+                    "type": "string"
+                },
+                "backgroundImage": {
+                    "description": "URL of image used to add a custom background and themify a block",
+                    "type": "string"
+                },
+                "blockTags": {
+                    "description": "Custom user input metadata in the block (e.g. instructor block can have cohorts mentioned)",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "position": {
+                    "description": "Title of a role",
+                    "type": "string"
+                },
+                "organizationName": {
+                    "description": "The name of the organization associated with the block",
+                    "type": "string"
+                },
+                "status": {
+                    "description": "The current status of the role",
+                    "type": "string"
+                },
+                "startDate": {
+                    "description": "The date the role or education starts",
+                    "type": "string"
+                },
+                "endDate": {
+                    "description": "The date the role or education ends",
+                    "type": "string"
+                },
+                "index": {
+                    "description": "Indexing data",
+                    "type": "object",
+                    "properties": {
+                        "d": {
+                            "description": "Index (SAID)",
+                            "type": "string"
+                        },
+                        "u": {
+                            "description": "Salty nonce for uniqueness",
+                            "type": "string"
+                        },
+                        "label": {
+                            "description": "A label for the versioned ACDC instance",
+                            "type": "string"
+                        }
+                    }
+                }
+            },
+            "additionalProperties": false
+        });
+        assert!(Schemer::new(Some(sed.to_json().unwrap().as_bytes()), None, None, None).is_ok());
+    }
+}

--- a/sample/keri/acdc/tel/management.rs
+++ b/sample/keri/acdc/tel/management.rs
@@ -1,0 +1,31 @@
+use crate::error::Result;
+use cesride::{
+    common::{versify, Ilkage, Serialage, CURRENT_VERSION},
+    data::dat,
+    matter, Matter, Prefixer, Sadder, Serder,
+};
+
+pub(crate) fn incept(issuer: &str) -> Result<(String, String)> {
+    let vs = versify(None, Some(CURRENT_VERSION), Some(Serialage::JSON), Some(0))?;
+
+    let mut ted = dat!({
+        "v": &vs,
+        "t": Ilkage::vcp,
+        "d": "",
+        "i": "",
+        "ii": issuer,
+        "s": "0",
+        "c": ["NB"],
+        "bt": "0",
+        "b": [],
+    });
+
+    let prefixer = Prefixer::new_with_ked(&ted, None, Some(matter::Codex::Blake3_256))?;
+    let prefix = prefixer.qb64()?;
+    ted["i"] = dat!(&prefix);
+    ted["d"] = dat!(&prefix);
+
+    let serder = Serder::new_with_ked(&ted, None, None)?;
+
+    Ok((prefix, String::from_utf8(serder.raw())?))
+}

--- a/sample/keri/acdc/tel/mod.rs
+++ b/sample/keri/acdc/tel/mod.rs
@@ -1,0 +1,3 @@
+pub(crate) mod management;
+pub(crate) mod vc;
+pub(crate) mod verification;

--- a/sample/keri/acdc/tel/vc.rs
+++ b/sample/keri/acdc/tel/vc.rs
@@ -1,0 +1,49 @@
+use crate::error::Result;
+use cesride::{
+    common::{versify, Ilkage, Serialage, CURRENT_VERSION},
+    data::dat,
+    Matter, Sadder, Saider, Salter, Serder,
+};
+
+pub(crate) fn issue(said: &str, ri: &str) -> Result<(String, String)> {
+    let vs = versify(None, Some(CURRENT_VERSION), Some(Serialage::JSON), Some(0))?;
+
+    let nonce = Salter::new_with_defaults(None)?.signer(None, Some(false), None, None, None)?;
+    let ted = dat!({
+        "v": &vs,
+        "t": Ilkage::iss,
+        "d": "",
+        "i": said,
+        "s": "0",
+        "ri": ri,
+        "dt": dat!(&chrono::Utc::now().format("%+").to_string()),
+        "n": &nonce.qb64()?,
+    });
+
+    let (_, ted) = Saider::saidify(&ted, None, None, None, None)?;
+    let serder = Serder::new_with_ked(&ted, None, None)?;
+
+    Ok((serder.said()?, String::from_utf8(serder.raw())?))
+}
+
+pub(crate) fn revoke(said: &str, ri: &str, prior: &str) -> Result<(String, String)> {
+    let vs = versify(None, Some(CURRENT_VERSION), Some(Serialage::JSON), Some(0))?;
+
+    let nonce = Salter::new_with_defaults(None)?.signer(None, Some(false), None, None, None)?;
+    let ted = dat!({
+        "v": &vs,
+        "t": Ilkage::rev,
+        "d": "",
+        "i": said,
+        "s": "1",
+        "ri": ri,
+        "p": prior,
+        "dt": dat!(&chrono::Utc::now().format("%+").to_string()),
+        "n": &nonce.qb64()?,
+    });
+
+    let (_, ted) = Saider::saidify(&ted, None, None, None, None)?;
+    let serder = Serder::new_with_ked(&ted, None, None)?;
+
+    Ok((serder.said()?, String::from_utf8(serder.raw())?))
+}

--- a/sample/keri/acdc/tel/verification.rs
+++ b/sample/keri/acdc/tel/verification.rs
@@ -1,0 +1,159 @@
+use crate::error::{err, Error, Result};
+
+use cesride::{common::Ilkage, Prefixer, Sadder, Serder};
+use parside::{message::SealSourceCouples, CesrGroup, Group, MessageList};
+
+use super::super::super::{labels, verification, KeriStore};
+
+use std::collections::HashSet;
+
+pub(crate) fn verify_transaction_event(
+    store: &impl KeriStore,
+    serder: &Serder,
+    seal_source_couples: &SealSourceCouples,
+    deep: Option<bool>,
+    verifying: Option<&mut HashSet<String>>,
+    _indent: usize,
+) -> Result<bool> {
+    let mut backing_set = HashSet::new();
+    let verifying = verifying.unwrap_or(&mut backing_set);
+
+    // println!("{:?}", verifying);
+
+    let pre = serder.pre()?;
+    let ked = serder.ked();
+
+    // see if code is supported
+    let prefixer = Prefixer::new_with_qb64(&pre)?;
+
+    let sn = serder.sn()?;
+    let ilk = ked["t"].to_string()?;
+    let said = serder.said()?;
+    let ri = verification::extract_registry_from_serder(&ilk, serder)?;
+
+    let mut existing = false;
+
+    if seal_source_couples.value.len() != 1 {
+        return err!(Error::Decoding);
+    }
+    let source_saider = &seal_source_couples.value()[0].saider;
+    let source_seqner = &seal_source_couples.value()[0].seqner;
+
+    let labels = match ilk.as_str() {
+        Ilkage::vcp => &labels::VCP_LABELS,
+        Ilkage::iss => &labels::ISS_LABELS,
+        Ilkage::rev => &labels::REV_LABELS,
+        _ => return err!(Error::Decoding),
+    };
+    if !verification::verify_ked_labels(&ked, labels)? {
+        return err!(Error::Validation);
+    }
+
+    let inceptive = ilk == Ilkage::vcp || ilk == Ilkage::iss;
+    let transaction_event_count = store.count_transaction_events(&pre)?;
+
+    let apre = match ilk.as_str() {
+        Ilkage::vcp => {
+            if !prefixer.verify(&ked, Some(true))? {
+                return err!(Error::Verification);
+            }
+
+            ked["ii"].to_string()?
+        }
+        Ilkage::iss | Ilkage::rev => {
+            if !serder.saider().verify(&ked, Some(false), Some(true), None, None, None)? {
+                return err!(Error::Verification);
+            }
+
+            let rievent = store.get_transaction_event(&ri, 0)?;
+            let riserder = Serder::new_with_raw(rievent.as_bytes())?;
+
+            riserder.ked()["ii"].to_string()?
+        }
+        _ => return err!(Error::Decoding),
+    };
+
+    if !verification::verify_anchor(
+        store,
+        &apre,
+        source_seqner,
+        source_saider,
+        serder,
+        deep,
+        Some(verifying),
+        _indent + 2,
+    )? {
+        return err!(Error::Verification);
+    }
+
+    if inceptive {
+        if sn != 0 {
+            // must be 0
+            return err!(Error::Decoding);
+        }
+
+        if transaction_event_count != 0 {
+            existing = true;
+        }
+    } else {
+        if sn < 1 {
+            return err!(Error::Validation);
+        }
+
+        let sno = transaction_event_count as u128;
+
+        if sn > sno {
+            // escrow here
+            return err!(Error::OutOfOrder);
+        }
+
+        if sn != sno {
+            existing = true;
+        }
+
+        // this sn implementation will become a problem at around 4 billion events
+        let event = store.get_transaction_event(&pre, sn as u32 - 1)?;
+        let pserder = Serder::new_with_raw(event.as_bytes())?;
+
+        if deep.unwrap_or(true) && !verifying.contains(&pserder.said()?) {
+            verifying.insert(pserder.said()?);
+
+            let (_, message_list) =
+                MessageList::from_stream_bytes(event[pserder.raw().len()..].as_bytes())?;
+            let group = message_list.messages[0].cesr_group()?;
+
+            match group {
+                CesrGroup::SealSourceCouplesVariant { value } => {
+                    verify_transaction_event(
+                        store,
+                        &pserder,
+                        value,
+                        deep,
+                        Some(verifying),
+                        _indent + 2,
+                    )?;
+                }
+                _ => return err!(Error::Decoding),
+            }
+        }
+
+        if pserder.said()? != serder.ked()["p"].to_string()? {
+            return err!(Error::Verification);
+        }
+    }
+
+    if existing {
+        let event = store.get_transaction_event(&pre, sn as u32)?;
+        let eserder = Serder::new_with_raw(event.as_bytes())?;
+
+        // this seems very bad, it means something is in the database that shouldn't be there. how did it get there?
+        if said != eserder.said()? {
+            return err!(Error::Programmer);
+        }
+    }
+
+    // println!("successfully verified transaction event [{pre}, {said}]");
+    // println!("t {}{said}", ' '.to_string().repeat(_indent));
+
+    Ok(existing)
+}

--- a/sample/keri/acdc/verification.rs
+++ b/sample/keri/acdc/verification.rs
@@ -1,0 +1,275 @@
+use crate::error::{err, Error, Result};
+
+use cesride::{
+    common::{Ids, Ilkage, Serialage},
+    Bext, Creder, Indexer, Matter, Sadder, Saider, Serder,
+};
+use parside::{message::AttachedMaterialQuadlets, CesrGroup, Group, MessageList};
+
+use super::super::{kmi, KeriStore};
+use super::schemer::cache as schema_cache;
+
+use std::collections::HashSet;
+
+const DEFAULT_CREDENTIAL_EXPIRY_SECONDS: i64 = 36000000000;
+
+pub(crate) fn verify_acdc(
+    store: &impl KeriStore,
+    creder: &Creder,
+    quadlets: &AttachedMaterialQuadlets,
+    deep: Option<bool>,
+    verifying: Option<&mut HashSet<String>>,
+    _indent: usize,
+) -> Result<bool> {
+    let mut backing_set = HashSet::new();
+    let verifying = verifying.unwrap_or(&mut backing_set);
+
+    if creder.status()?.is_none() {
+        return err!(Error::Validation);
+    };
+
+    let vcid = creder.said()?;
+    let schema = creder.schema()?;
+    let prov = creder.chains()?;
+
+    let saider = Saider::new_with_qb64(&vcid)?;
+    if !saider.verify(&creder.crd(), Some(false), Some(true), Some(Serialage::JSON), None, None)? {
+        return err!(Error::Verification);
+    }
+
+    let event = store.get_latest_transaction_event(&vcid)?;
+    let state = Serder::new_with_raw(event.as_bytes())?;
+    let dtnow = chrono::Utc::now();
+    let dte = chrono::DateTime::parse_from_rfc3339(&state.ked()["dt"].to_string()?)?
+        .with_timezone(&chrono::Utc);
+    if (dtnow - dte).num_seconds() > DEFAULT_CREDENTIAL_EXPIRY_SECONDS {
+        return err!(Error::Validation);
+    }
+
+    if deep.unwrap_or(true) && !verifying.contains(&state.said()?) {
+        verifying.insert(state.said()?);
+
+        let (_, message_list) =
+            MessageList::from_stream_bytes(event[state.raw().len()..].as_bytes())?;
+        let group = message_list.messages[0].cesr_group()?;
+
+        match group {
+            CesrGroup::SealSourceCouplesVariant { value } => {
+                super::tel::verification::verify_transaction_event(
+                    store,
+                    &state,
+                    value,
+                    deep,
+                    Some(verifying),
+                    _indent + 2,
+                )?;
+            }
+            _ => return err!(Error::Decoding),
+        }
+    }
+
+    // added brv here for safety even though unimplemented
+    if [Ilkage::rev, Ilkage::brv].contains(&state.ked()[Ids::t].to_string()?.as_str()) {
+        return err!(Error::Validation);
+    }
+
+    if !schema_cache().verify(&schema, std::str::from_utf8(&creder.raw())?)? {
+        return err!(Error::Validation);
+    }
+
+    let mut rooted = false;
+
+    for group in quadlets.value() {
+        match group {
+            CesrGroup::SadPathSigVariant { value } => {
+                for sad_path_sig in value.value() {
+                    if sad_path_sig.pather.bext()? != "-" {
+                        continue;
+                    }
+
+                    rooted = true;
+
+                    let event = store.get_key_event(
+                        &sad_path_sig.prefixer.qb64()?,
+                        sad_path_sig.seqner.sn()? as u32,
+                    )?;
+                    let serder = Serder::new_with_raw(event.as_bytes())?;
+                    if serder.said()? != sad_path_sig.saider.qb64()? {
+                        return err!(Error::Verification);
+                    }
+
+                    if deep.unwrap_or(true) && !verifying.contains(&serder.said()?) {
+                        verifying.insert(serder.said()?);
+
+                        let (_, message_list) =
+                            MessageList::from_stream_bytes(event[serder.raw().len()..].as_bytes())?;
+                        let group = message_list.messages[0].cesr_group()?;
+
+                        match group {
+                            CesrGroup::AttachedMaterialQuadletsVariant { value } => {
+                                kmi::verification::verify_key_event(
+                                    store,
+                                    &serder,
+                                    value,
+                                    deep,
+                                    Some(verifying),
+                                    _indent + 2,
+                                )?;
+                            }
+                            _ => return err!(Error::Decoding),
+                        }
+                    }
+
+                    let verfers = serder.verfers()?;
+                    let mut sigers = vec![];
+                    for controller_idx_sig in sad_path_sig.sigers.value() {
+                        let siger = &controller_idx_sig.siger;
+                        if !sigers.contains(siger) {
+                            sigers.push(siger.clone())
+                        }
+                    }
+
+                    let mut verified_indices = vec![];
+                    for siger in sigers {
+                        if siger.index() as usize > verfers.len() {
+                            return err!(Error::Verification);
+                        }
+
+                        if verfers[siger.index() as usize].verify(&siger.raw(), &creder.raw())? {
+                            verified_indices.push(siger.index());
+                        }
+                    }
+
+                    if let Some(tholder) = serder.tholder()? {
+                        if !tholder.satisfy(&verified_indices)? {
+                            return err!(Error::Verification);
+                        }
+                    } else {
+                        return err!(Error::Verification);
+                    }
+                }
+            }
+            _ => return err!(Error::Decoding),
+        }
+    }
+
+    if !rooted {
+        return err!(Error::Verification);
+    }
+
+    let edges = if prov.to_map().is_ok() {
+        vec![prov]
+    } else if prov.to_vec().is_ok() {
+        prov.to_vec()?
+    } else {
+        return err!(Error::Verification);
+    };
+
+    for edge in &edges {
+        for (label, node) in edge.to_map()? {
+            if [Ids::d, "o"].contains(&label.as_str()) {
+                continue;
+            }
+
+            let map = node.to_map()?;
+
+            let node_said = map["n"].to_string()?;
+            let message = store.get_acdc(&node_said)?;
+            let pacdc = Creder::new_with_raw(message.as_bytes())?;
+
+            if map.contains_key("s") {
+                let node_schema = map["s"].to_string()?;
+                if !schema_cache().verify(&node_schema, std::str::from_utf8(&pacdc.raw())?)? {
+                    return err!(Error::Validation);
+                }
+            }
+
+            let mut operators = if map.contains_key("o") {
+                let result = map["o"].to_string();
+                if result.is_ok() {
+                    vec![result?]
+                } else {
+                    map["o"].to_vec()?.iter().map(|o| o.to_string().unwrap()).collect()
+                }
+            } else {
+                vec![]
+            };
+
+            // capture not, and remove everything but unary operators
+            let not = operators.contains(&"NOT".to_string());
+            if not {
+                return err!(Error::Value);
+            }
+            let mut indices = vec![];
+            for (i, value) in operators.iter().enumerate() {
+                if value == "NOT" || !["I2I", "NI2I", "DI2I"].contains(&value.as_str()) {
+                    indices.push(i);
+                }
+            }
+            indices.reverse();
+            for index in indices {
+                operators.remove(index);
+            }
+
+            // if we have nothing left, add defaults
+            let node_subject = pacdc.subject().to_map()?;
+            if operators.is_empty() {
+                if node_subject.contains_key(&"i".to_string()) {
+                    operators.push("I2I".to_string());
+                } else {
+                    operators.push("NI2I".to_string());
+                }
+            }
+
+            // if the programmer specified two unary operators, we have a problem
+            if operators.len() != 1 {
+                return err!(Error::Validation);
+            }
+
+            // actual validation logic
+            match operators[0].as_str() {
+                "I2I" => {
+                    if node_subject["i"].to_string()? != creder.issuer()? {
+                        return err!(Error::Validation);
+                    }
+                }
+                "NI2I" => {}
+                "DI2I" => unimplemented!(),
+                _ => return err!(Error::Validation),
+            }
+
+            // here we need to default to true
+            if deep.unwrap_or(true) && !verifying.contains(&node_said) {
+                verifying.insert(node_said);
+
+                let (_, message_list) =
+                    MessageList::from_stream_bytes(message[pacdc.raw().len()..].as_bytes())?;
+                let group = message_list.messages[0].cesr_group()?;
+
+                match group {
+                    CesrGroup::AttachedMaterialQuadletsVariant { value } => {
+                        verify_acdc(store, &pacdc, value, deep, Some(verifying), _indent + 2)?;
+                    }
+                    _ => return err!(Error::Decoding),
+                }
+            }
+        }
+    }
+
+    let result = store.get_acdc(&vcid);
+    let existing = result.is_ok();
+    if existing {
+        let message = result.unwrap();
+        let eacdc = Creder::new_with_raw(message.as_bytes())?;
+
+        // this seems very bad, it means something is in the database that shouldn't be there. how did it get there?
+        if vcid != eacdc.said()? {
+            return err!(Error::Programmer);
+        }
+    }
+
+    // println!("successfully verified acdc {vcid}");
+    // println!("a {}{vcid}", ' '.to_string().repeat(_indent));
+
+    Ok(existing)
+}

--- a/sample/keri/kmi/endorsement.rs
+++ b/sample/keri/kmi/endorsement.rs
@@ -1,0 +1,91 @@
+use crate::error::{err, Error, Result};
+use cesride::{common::Ids, counter, data::Value, Cigar, Counter, Indexer, Matter, Seqner, Siger};
+
+#[derive(Debug, Clone)]
+pub(crate) struct Seal {
+    value: Value,
+    last: bool,
+}
+
+impl Seal {
+    #[allow(dead_code)]
+    pub fn new(value: &Value, last: bool) -> Self {
+        Seal { value: value.clone(), last }
+    }
+
+    pub fn value(&self) -> Value {
+        self.value.clone()
+    }
+
+    pub fn last(&self) -> bool {
+        self.last
+    }
+}
+
+pub(crate) fn endorse_serder(
+    sigers: Option<&[Siger]>,
+    seal: Option<&Seal>,
+    wigers: Option<&[Siger]>,
+    cigars: Option<&[Cigar]>,
+) -> Result<String> {
+    let mut atc = "".to_string();
+
+    if sigers.is_none() && wigers.is_none() && cigars.is_none() {
+        return err!(Error::Value);
+    }
+
+    if let Some(sigers) = sigers {
+        if let Some(seal) = seal {
+            if seal.last() {
+                atc += &Counter::new_with_code_and_count(counter::Codex::TransLastIdxSigGroups, 1)?
+                    .qb64()?;
+                atc += &seal.value()[Ids::i].to_string()?;
+            } else {
+                atc += &Counter::new_with_code_and_count(counter::Codex::TransIdxSigGroups, 1)?
+                    .qb64()?;
+                atc += &seal.value()[Ids::i].to_string()?;
+                atc += &Seqner::new_with_snh(&seal.value()[Ids::s].to_string()?)?.qb64()?;
+                atc += &seal.value()[Ids::d].to_string()?;
+            }
+        }
+
+        atc += &Counter::new_with_code_and_count(
+            counter::Codex::ControllerIdxSigs,
+            sigers.len() as u32,
+        )?
+        .qb64()?;
+        for siger in sigers {
+            atc += &siger.qb64()?;
+        }
+    }
+
+    if let Some(wigers) = wigers {
+        atc +=
+            &Counter::new_with_code_and_count(counter::Codex::WitnessIdxSigs, wigers.len() as u32)?
+                .qb64()?;
+        for wiger in wigers {
+            if wiger.verfer().transferable() {
+                return err!(Error::Encoding);
+            }
+
+            atc += &wiger.qb64()?;
+        }
+    }
+
+    if let Some(cigars) = cigars {
+        atc += &Counter::new_with_code_and_count(
+            counter::Codex::NonTransReceiptCouples,
+            cigars.len() as u32,
+        )?
+        .qb64()?;
+        for cigar in cigars {
+            if cigar.verfer().transferable() {
+                return err!(Error::Encoding);
+            }
+
+            atc += &cigar.qb64()?;
+        }
+    }
+
+    Ok(atc)
+}

--- a/sample/keri/kmi/event.rs
+++ b/sample/keri/kmi/event.rs
@@ -1,0 +1,445 @@
+use crate::error::{err, Error, Result};
+use cesride::{
+    common::{versify, Ids, Ilkage, Serialage, Version, CURRENT_VERSION},
+    data::{dat, Value},
+    matter, Matter, Number, Prefixer, Saider, Serder, Tholder,
+};
+
+use super::endorsement::Seal;
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn incept(
+    keys: &[String],           // current keys public qb64
+    sith: Option<&Value>,      // current signing threshold
+    ndigs: Option<&[String]>,  // next keys public digest qb64
+    nsith: Option<&Value>,     // next signing threshold
+    toad: Option<u128>,        // witness threshold number
+    wits: Option<&[String]>,   // witness identifier prefixes qb64
+    cnfg: Option<&[&str]>,     // configuration traits from traiter::Codex
+    data: Option<&[Seal]>,     // seal dicts
+    version: Option<&Version>, // protocol version
+    kind: Option<&str>,        // serder serialization kind
+    code: Option<&str>,        // serder code
+    intive: Option<bool>,      // sith, nsith and toad are ints, not hex when numeric
+    delpre: Option<&str>,      // delegator identifier prefix
+) -> Result<Serder> {
+    let version = version.unwrap_or(CURRENT_VERSION);
+    let kind = kind.unwrap_or(Serialage::JSON);
+    let intive = intive.unwrap_or(false);
+
+    let vs = &versify(None, Some(version), Some(kind), Some(0))?;
+    let ilk = if delpre.is_none() { Ilkage::icp } else { Ilkage::dip };
+    let sner = Number::new_with_num(0)?;
+
+    let sith = if let Some(sith) = sith {
+        sith.clone()
+    } else {
+        let mut s: i64 = (keys.len() as i64 + 1) / 2;
+        s = if s > 1 { s } else { 1 };
+        dat!(s)
+    };
+
+    let tholder = Tholder::new_with_sith(&sith)?;
+    if tholder.num()?.unwrap_or(1) < 1 {
+        return err!(Error::Value);
+    }
+    if tholder.size() as usize > keys.len() {
+        return err!(Error::Value);
+    }
+
+    let empty_string_vec: Vec<String> = vec![];
+    let ndigs = ndigs.unwrap_or(&empty_string_vec);
+    let nsith = if let Some(nsith) = nsith {
+        nsith.clone()
+    } else {
+        let mut s: i64 = (ndigs.len() as i64 + 1) / 2;
+        s = if s > 0 { s } else { 0 };
+        dat!(s)
+    };
+
+    let ntholder = Tholder::new_with_sith(&nsith)?;
+    if ntholder.size() as usize > ndigs.len() {
+        return err!(Error::Value);
+    }
+
+    let wits = wits.unwrap_or(&[]);
+    let mut unique = wits.to_vec();
+    unique.sort_unstable();
+    unique.dedup();
+    if wits.len() != unique.len() {
+        return err!(Error::Value);
+    }
+
+    let toader = if let Some(toad) = toad {
+        Number::new_with_num(toad)?
+    } else if wits.is_empty() {
+        Number::new_with_num(0)?
+    } else {
+        let toad = ample(wits.len() as u128, None, None)?;
+        Number::new_with_num(toad)?
+    };
+
+    if !wits.is_empty() {
+        if toader.num()? < 1 || toader.num()? > wits.len() as u128 {
+            return err!(Error::Value);
+        }
+    } else if toader.num()? != 0 {
+        return err!(Error::Value);
+    }
+
+    let cnfg = cnfg.unwrap_or(&[]);
+    let data: Vec<Value> = data.unwrap_or(&[]).iter().map(|seal| seal.value()).collect();
+
+    let kt = if let Some(n) = tholder.num()? {
+        if intive && n < u32::MAX {
+            dat!(n)
+        } else {
+            tholder.sith()?
+        }
+    } else {
+        tholder.sith()?
+    };
+
+    let nt = if let Some(n) = ntholder.num()? {
+        if intive && n < u32::MAX {
+            dat!(n)
+        } else {
+            ntholder.sith()?
+        }
+    } else {
+        ntholder.sith()?
+    };
+
+    let toad = if intive && toader.num()? < u32::MAX as u128 {
+        dat!(toader.num()? as i64)
+    } else {
+        dat!(&toader.numh()?)
+    };
+
+    let keys: Vec<Value> = keys.iter().map(|key| dat!(key)).collect();
+    let ndigs: Vec<Value> = ndigs.iter().map(|dig| dat!(dig)).collect();
+    let wits: Vec<Value> = wits.iter().map(|wit| dat!(wit)).collect();
+    let cnfg: Vec<Value> = cnfg.iter().map(|cfg| dat!(*cfg)).collect();
+
+    let mut ked = dat!({
+        "v": vs,
+        "t": ilk,
+        "d": "",
+        "i": "",
+        "s": &sner.numh()?,
+        "kt": kt,
+        "k": keys.as_slice(),
+        "nt": nt,
+        "n": ndigs.as_slice(),
+        "bt": toad,
+        "b": wits.as_slice(),
+        "c": cnfg.as_slice(),
+        "a": data.as_slice(),
+    });
+
+    let code = if let Some(delpre) = delpre {
+        let label = Ids::di;
+        ked[label] = dat!(delpre);
+        Some(code.unwrap_or(matter::Codex::Blake3_256))
+    } else {
+        code
+    };
+
+    let prefixer = if delpre.is_none() && code.is_none() && keys.len() == 1 {
+        let prefixer = Prefixer::new_with_qb64(&keys[0].to_string()?)?;
+        if prefixer.digestive() {
+            return err!(Error::Value);
+        }
+        prefixer
+    } else {
+        let prefixer = Prefixer::new_with_ked(&ked, None, code)?;
+        if delpre.is_some() && !prefixer.digestive() {
+            return err!(Error::Value);
+        }
+        prefixer
+    };
+
+    let label = Ids::i;
+    ked[label] = dat!(&prefixer.qb64()?);
+    let ked = if prefixer.digestive() {
+        let label = Ids::d;
+        ked[label] = dat!(&prefixer.qb64()?);
+        ked
+    } else {
+        let (_, ked) = Saider::saidify(&ked, None, None, None, None)?;
+        ked
+    };
+
+    Serder::new_with_ked(&ked, None, None)
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn rotate(
+    pre: &str,                // prefix of identifier
+    keys: &[String],          // current signing keys
+    dig: &str,                // said of previous estabishment event
+    ilk: Option<&str>,        // must be 'rot' or 'drt'
+    sn: u128,                 // sequence number
+    sith: Option<&Value>,     // current signing sith (must match previous event's next sith?)
+    ndigs: Option<&[String]>, // next keys' digests
+    nsith: Option<&Value>,    // next signing sith
+    toad: Option<u128>,       // witness threshold number
+    wits: Option<&[String]>,  // witness prefixes
+    cuts: Option<&[String]>,  // witnesses prefixes to cut
+    adds: Option<&[String]>,  // witnesses prefixes to add
+    data: Option<&[Seal]>,    // seals
+    version: Option<&Version>,
+    kind: Option<&str>,
+    intive: Option<bool>,
+) -> Result<Serder> {
+    let ilk = ilk.unwrap_or(Ilkage::rot);
+    let version = version.unwrap_or(CURRENT_VERSION);
+    let kind = kind.unwrap_or(Serialage::JSON);
+    let intive = intive.unwrap_or(false);
+
+    let vs = versify(None, Some(version), Some(kind), None)?;
+    if ![Ilkage::rot, Ilkage::drt].contains(&ilk) {
+        return err!(Error::Value);
+    }
+
+    let sner = Number::new_with_num(sn)?;
+    if sner.num()? < 1 {
+        return err!(Error::Value);
+    }
+
+    let sith = if let Some(sith) = sith {
+        sith.clone()
+    } else {
+        let mut s: i64 = (keys.len() as i64 + 1) / 2;
+        s = if s > 1 { s } else { 1 };
+        dat!(s)
+    };
+
+    let tholder = Tholder::new_with_sith(&sith)?;
+    let num = tholder.num()?;
+    if let Some(num) = num {
+        if num < 1 {
+            return err!(Error::Value);
+        }
+    }
+    if tholder.size() as usize > keys.len() {
+        return err!(Error::Value);
+    }
+
+    let empty_string_vec: Vec<String> = vec![];
+    let ndigs = ndigs.unwrap_or(&empty_string_vec);
+    let nsith = if let Some(nsith) = nsith {
+        nsith.clone()
+    } else {
+        let mut s: i64 = (ndigs.len() as i64 + 1) / 2;
+        s = if s > 0 { s } else { 0 };
+        dat!(s)
+    };
+
+    let ntholder = Tholder::new_with_sith(&nsith)?;
+    let num = ntholder.num()?;
+    if let Some(num) = num {
+        if num < 1 {
+            return err!(Error::Value);
+        }
+    }
+    if ntholder.size() as usize > ndigs.len() {
+        return err!(Error::Value);
+    }
+
+    let wits = wits.unwrap_or(&empty_string_vec);
+    let mut unique = wits.to_vec();
+    unique.sort_unstable();
+    unique.dedup();
+    if wits.len() != unique.len() {
+        return err!(Error::Value);
+    }
+
+    let cuts = cuts.unwrap_or(&empty_string_vec);
+    let mut unique = cuts.to_vec();
+    unique.sort_unstable();
+    unique.dedup();
+    if cuts.len() != unique.len() {
+        return err!(Error::Value);
+    }
+
+    let adds = adds.unwrap_or(&empty_string_vec);
+    let mut unique = adds.to_vec();
+    unique.sort_unstable();
+    unique.dedup();
+    if adds.len() != unique.len() {
+        return err!(Error::Value);
+    }
+
+    for cut in cuts {
+        if adds.contains(cut) {
+            return err!(Error::Value);
+        }
+    }
+
+    for wit in wits {
+        if adds.contains(wit) {
+            return err!(Error::Value);
+        }
+    }
+
+    let mut newits = wits.to_vec();
+    let mut to_remove = vec![0usize; 0];
+    for (index, wit) in newits.iter().enumerate() {
+        if cuts.contains(wit) {
+            to_remove.push(index);
+        }
+    }
+    to_remove.iter().for_each(|index| {
+        newits.remove(*index);
+    });
+
+    for add in adds {
+        newits.push(add.clone());
+    }
+
+    let toader = if let Some(toad) = toad {
+        Number::new_with_num(toad)?
+    } else {
+        let toad = if newits.is_empty() { 0 } else { ample(newits.len() as u128, None, None)? };
+
+        Number::new_with_num(toad)?
+    };
+
+    if newits.is_empty() {
+        if toader.num()? != 0 {
+            return err!(Error::Value);
+        }
+    } else if toader.num()? < 1 || toader.num()? > newits.len() as u128 {
+        return err!(Error::Value);
+    }
+
+    let data: Vec<Value> = data.unwrap_or(&[]).iter().map(|seal| seal.value()).collect();
+
+    let kt = if let Some(n) = tholder.num()? {
+        if intive && n < u32::MAX {
+            dat!(n)
+        } else {
+            tholder.sith()?
+        }
+    } else {
+        tholder.sith()?
+    };
+
+    let nt = if let Some(n) = ntholder.num()? {
+        if intive && n < u32::MAX {
+            dat!(n)
+        } else {
+            ntholder.sith()?
+        }
+    } else {
+        ntholder.sith()?
+    };
+
+    let toad = if intive && toader.num()? < u32::MAX as u128 {
+        dat!(toader.num()? as i64)
+    } else {
+        dat!(&toader.numh()?)
+    };
+
+    let keys: Vec<Value> = keys.iter().map(|key| dat!(key)).collect();
+    let ndigs: Vec<Value> = ndigs.iter().map(|dig| dat!(dig)).collect();
+    let cuts: Vec<Value> = cuts.iter().map(|wit| dat!(wit)).collect();
+    let adds: Vec<Value> = adds.iter().map(|wit| dat!(wit)).collect();
+
+    let ked = dat!({
+        "v": &vs,
+        "t": ilk,
+        "d": "",
+        "i": pre,
+        "s": &sner.numh()?,
+        "p": dig,
+        "kt": kt,
+        "k": keys.as_slice(),
+        "nt": nt,
+        "n": ndigs.as_slice(),
+        "bt": toad,
+        "br": cuts.as_slice(),
+        "ba": adds.as_slice(),
+        "a": data.as_slice()
+    });
+    let (_, ked) = Saider::saidify(&ked, None, None, None, None)?;
+
+    Serder::new_with_ked(&ked, None, None)
+}
+
+pub(crate) fn interact(
+    pre: &str,
+    dig: &str,
+    sn: Option<u128>,
+    data: Option<&Value>,
+    version: Option<&Version>,
+    kind: Option<&str>,
+) -> Result<Serder> {
+    let sn = sn.unwrap_or(1);
+    let version = version.unwrap_or(CURRENT_VERSION);
+    let kind = kind.unwrap_or(Serialage::JSON);
+
+    let vs = versify(None, Some(version), Some(kind), Some(0))?;
+    let ilk = Ilkage::ixn;
+    let sner = Number::new_with_num(sn)?;
+
+    if sner.num()? < 1 {
+        return err!(Error::Value);
+    }
+
+    let empty_list = dat!([]);
+    let data = data.unwrap_or(&empty_list);
+
+    let ked = dat!({
+        "v": &vs,
+        "t": ilk,
+        "d": "",
+        "i": pre,
+        "s": &sner.numh()?,
+        "p": dig,
+        "a": data.clone()
+    });
+
+    let (_, ked) = Saider::saidify(&ked, None, None, None, None)?;
+
+    Serder::new_with_ked(&ked, None, None)
+}
+
+fn ample(n: u128, f: Option<u128>, weak: Option<bool>) -> Result<u128> {
+    let weak = weak.unwrap_or(true);
+    let n = if n > 0 { n } else { 0 };
+    if let Some(f) = f {
+        let f = if f > 0 { f } else { 0 };
+        let m1 = (n + f + 2) / 2;
+        let m2 = if n - f > 0 { n - f } else { 0 };
+
+        if m2 < m1 && n > 0 {
+            return err!(Error::Value);
+        }
+
+        if weak {
+            match [n, m1, m2].iter().min() {
+                Some(x) => Ok(*x),
+                None => unreachable!(),
+            }
+        } else {
+            Ok(std::cmp::min(n, std::cmp::max(m1, m2)))
+        }
+    } else {
+        let f1 = std::cmp::max(1, std::cmp::max(0, n - 1) / 3);
+        let f2 = std::cmp::max(1, (std::cmp::max(0, n - 1) + 2) / 3);
+
+        if weak {
+            match [n, (n + f1 + 3) / 2, (n + f2 + 3) / 2].iter().min() {
+                Some(x) => Ok(*x),
+                None => unreachable!(),
+            }
+        } else {
+            match [0, n - f1, (n + f1 + 3) / 2].iter().max() {
+                Some(x) => Ok(std::cmp::min(n, *x)),
+                None => unreachable!(),
+            }
+        }
+    }
+}

--- a/sample/keri/kmi/message.rs
+++ b/sample/keri/kmi/message.rs
@@ -1,0 +1,58 @@
+use crate::error::{err, Error, Result};
+use cesride::{
+    common::{versify, Ilkage, Serialage, Version, CURRENT_VERSION},
+    counter,
+    data::dat,
+    Counter, Number, Sadder, Serder,
+};
+
+pub(crate) fn messagize_serder(
+    serder: &Serder,
+    endorsement: &str,
+    pipelined: Option<bool>,
+) -> Result<String> {
+    let message = String::from_utf8(serder.raw())?;
+
+    let pipeline_glue = if pipelined.unwrap_or(false) {
+        if endorsement.len() % 4 != 0 {
+            return err!(Error::Value);
+        }
+
+        Counter::new_with_code_and_count(
+            counter::Codex::AttachedMaterialQuadlets,
+            (endorsement.len() / 4) as u32,
+        )?
+        .qb64()?
+    } else {
+        "".to_string()
+    };
+
+    Ok(message + &pipeline_glue + endorsement)
+}
+
+#[allow(dead_code)]
+pub(crate) fn receipt(
+    pre: &str,
+    sn: u128,
+    said: &str,
+    version: Option<&Version>,
+    kind: Option<&str>,
+) -> Result<Serder> {
+    let version = version.unwrap_or(CURRENT_VERSION);
+    let kind = kind.unwrap_or(Serialage::JSON);
+
+    let vs = versify(None, Some(version), Some(kind), Some(0))?;
+    let ilk = Ilkage::rct;
+
+    let sner = Number::new_with_num(sn)?;
+
+    let ked = dat!({
+        "v": &vs,
+        "t": ilk,
+        "d": said,
+        "i": pre,
+        "s": &sner.numh()?
+    });
+
+    Serder::new_with_ked(&ked, None, None)
+}

--- a/sample/keri/kmi/mod.rs
+++ b/sample/keri/kmi/mod.rs
@@ -1,0 +1,467 @@
+use crate::error::{err, Error, Result};
+use cesride::{
+    data::{dat, Value},
+    matter, Diger, Matter, Sadder, Salter,
+};
+
+use super::KeySet;
+
+pub(crate) mod endorsement;
+pub(crate) mod event;
+pub(crate) mod message;
+pub(crate) mod verification;
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum KeyKind {
+    Ed25519,
+    Secp256k1,
+    Secp256r1,
+}
+
+impl KeyKind {
+    pub fn to_cesr_code(&self) -> &str {
+        match self {
+            Self::Ed25519 => matter::Codex::Ed25519_Seed,
+            Self::Secp256k1 => matter::Codex::ECDSA_256k1_Seed,
+            Self::Secp256r1 => matter::Codex::ECDSA_256r1_Seed,
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn incept_partial(
+    code: Option<&str>,
+    scount: Option<usize>,
+    rcount: Option<usize>, // count of keys to keep in reserve for rotation
+    transferable: Option<bool>,
+    pcode: Option<&str>,
+    tier: Option<&str>,
+    salt: Option<&[u8]>,
+    next_keys: Option<&[&str]>,
+    next_sith: Option<&str>,
+) -> Result<(String, Vec<String>, String)> {
+    let scount = scount.unwrap_or(2);
+    let mut rcount = rcount.unwrap_or(3);
+    let sn = 0u128;
+
+    #[cfg(not(test))]
+    let temp: Option<bool> = None;
+    #[cfg(test)]
+    let temp: Option<bool> = Some(true);
+
+    let salter = Salter::new_with_defaults(tier)?;
+    let signers0 = salter.signers(
+        Some(scount),
+        None,
+        Some(&sn.to_string()),
+        code,
+        transferable,
+        None,
+        temp,
+    )?;
+    let mut keys = vec![];
+    for signer in &signers0 {
+        keys.push(signer.verfer().qb64()?);
+    }
+
+    let mut ndigs = vec![];
+    if let Some(next_keys) = next_keys {
+        for key in next_keys {
+            ndigs.push(key.to_string());
+        }
+        rcount = ndigs.len();
+    } else {
+        let signers1 = if transferable.unwrap_or(false) {
+            if let Some(salt) = salt {
+                let salter = Salter::new(tier, None, Some(salt), None, None, None)?;
+                salter.signers(
+                    Some(rcount),
+                    None,
+                    Some(&(sn + 1).to_string()),
+                    code,
+                    transferable,
+                    None,
+                    temp,
+                )?
+            } else {
+                return err!(Error::Programmer);
+            }
+        } else {
+            vec![]
+        };
+        for signer in &signers1 {
+            ndigs.push(Diger::new_with_ser(&signer.verfer().qb64b()?, None)?.qb64()?);
+        }
+    }
+
+    // println!("{:?}", signers1.iter().map(|signer| signer.verfer().qb64().unwrap()).collect::<Vec<String>>());
+
+    let mut sith = vec![];
+    for _ in 0..scount {
+        sith.push(dat!(&format!("1/{scount}")));
+    }
+    let sith = dat!([dat!(sith.as_slice())]);
+
+    let nsith: Value = if let Some(next_sith) = next_sith {
+        let value: serde_json::Value = serde_json::from_str(next_sith)?;
+        Value::from(&value)
+    } else {
+        let mut nsith = vec![];
+        for _ in 0..rcount {
+            nsith.push(dat!(&format!("1/{rcount}")));
+        }
+        dat!([dat!(nsith.as_slice())])
+    };
+
+    let serder = event::incept(
+        &keys,
+        Some(&sith),
+        Some(&ndigs),
+        Some(&nsith),
+        Some(0),
+        None, // Some(&wits),
+        None,
+        None,
+        None,
+        None,
+        pcode,
+        None,
+        None,
+    )?;
+
+    let mut privates = vec![];
+    for signer in &signers0 {
+        privates.push(signer.qb64()?);
+    }
+
+    let mut sigers = vec![];
+    for (index, signer) in signers0.iter().enumerate() {
+        let siger = signer.sign_indexed(&serder.raw(), false, index as u32, None)?;
+        sigers.push(siger);
+    }
+
+    let endorsement = endorsement::endorse_serder(Some(&sigers), None, None, None)?;
+    let event = message::messagize_serder(&serder, &endorsement, Some(true))?;
+
+    Ok((serder.pre()?, privates, event))
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn incept(
+    code: Option<&str>,
+    count: Option<usize>,
+    sith: Option<&Value>,
+    ncode: Option<&str>,
+    ncount: Option<usize>,
+    nsith: Option<&Value>,
+    wcount: Option<usize>,
+    transferable: Option<bool>,
+    pcode: Option<&str>,
+    tier: Option<&str>,
+) -> Result<(String, Vec<Vec<String>>, String)> {
+    let salter = Salter::new_with_defaults(tier)?;
+
+    #[cfg(not(test))]
+    let temp: Option<bool> = None;
+    #[cfg(test)]
+    let temp: Option<bool> = Some(true);
+
+    let signers0 = salter.signers(count, None, Some("0"), code, transferable, None, temp)?;
+    let mut keys = vec![];
+    for signer in &signers0 {
+        keys.push(signer.verfer().qb64()?);
+    }
+
+    let signers1 = if transferable.unwrap_or(false) {
+        salter.signers(ncount, None, Some("1"), ncode, transferable, None, temp)?
+    } else {
+        vec![]
+    };
+    let mut ndigs = vec![];
+    for signer in &signers1 {
+        ndigs.push(Diger::new_with_ser(&signer.verfer().qb64b()?, None)?.qb64()?);
+    }
+
+    let wcount = wcount.map(|wcount| wcount as u128);
+    let serder = event::incept(
+        &keys,
+        sith,
+        Some(&ndigs),
+        nsith,
+        wcount,
+        None, // Some(&wits),
+        None,
+        None,
+        None,
+        None,
+        pcode,
+        None,
+        None,
+    )?;
+
+    let mut result = vec![];
+
+    for signers in &[signers0.clone(), signers1] {
+        let mut privates = vec![];
+        for signer in signers {
+            privates.push(signer.qb64()?);
+        }
+        result.push(privates);
+    }
+
+    let mut sigers = vec![];
+    for (index, signer) in signers0.iter().enumerate() {
+        let siger = signer.sign_indexed(&serder.raw(), false, index as u32, None)?;
+        sigers.push(siger);
+    }
+
+    let endorsement = endorsement::endorse_serder(Some(&sigers), None, None, None)?;
+    let event = message::messagize_serder(&serder, &endorsement, Some(true))?;
+
+    Ok((serder.pre()?, result, event))
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn rotate_partial(
+    pre: &str,
+    dig: &str,
+    sn: u128,
+    key_sn: u128,
+    code: Option<&str>,
+    scount: Option<usize>,
+    rcount: Option<usize>,
+    tier: Option<&str>,
+    salt: Option<&[u8]>,
+    next_salt: Option<&[u8]>,
+    current_rotation_keys: Option<&[&str]>,
+    next_keys: Option<&[&str]>,
+    next_sith: Option<&str>,
+) -> Result<(String, usize, Vec<String>, String)> {
+    let scount = scount.unwrap_or(2);
+    let mut rcount = rcount.unwrap_or(3);
+    let mut ccount = rcount;
+
+    #[cfg(not(test))]
+    let temp: Option<bool> = None;
+    #[cfg(test)]
+    let temp: Option<bool> = Some(true);
+
+    let salter = Salter::new_with_defaults(tier)?;
+    let mut ssigners = salter.signers(
+        Some(scount),
+        None,
+        Some(&key_sn.to_string()),
+        code,
+        Some(true),
+        None,
+        temp,
+    )?;
+
+    let mut keys = vec![];
+    let (public_keys, ndigs, signers) = if let Some(salt) = salt {
+        if current_rotation_keys.is_some() || next_keys.is_some() || next_sith.is_some() {
+            return err!(Error::Value);
+        }
+
+        let next_salt = if let Some(next_salt) = next_salt {
+            next_salt
+        } else {
+            return err!(Error::Value);
+        };
+
+        let salter = Salter::new(tier, None, Some(salt), None, None, None)?;
+        let mut signers = salter.signers(
+            Some(rcount),
+            None,
+            Some(&key_sn.to_string()),
+            code,
+            Some(true),
+            None,
+            temp,
+        )?;
+        let salter = Salter::new(tier, None, Some(next_salt), None, None, None)?;
+        let nsigners = salter.signers(
+            Some(rcount),
+            None,
+            Some(&(key_sn + 1).to_string()),
+            code,
+            Some(true),
+            None,
+            temp,
+        )?;
+
+        signers.append(&mut ssigners);
+
+        let mut public_keys = vec![];
+        for signer in &signers {
+            keys.push(signer.qb64()?);
+            public_keys.push(signer.verfer().qb64()?);
+        }
+
+        let mut ndigs = vec![];
+        for nsigner in &nsigners {
+            ndigs.push(Diger::new_with_ser(&nsigner.verfer().qb64b()?, None)?.qb64()?);
+        }
+
+        (public_keys, ndigs, signers)
+    } else {
+        if current_rotation_keys.is_none() || next_keys.is_none() || next_sith.is_none() {
+            return err!(Error::Value);
+        }
+        if salt.is_some() || next_salt.is_some() {
+            return err!(Error::Value);
+        }
+
+        let mut public_keys: Vec<String> =
+            current_rotation_keys.unwrap().iter().map(|s| s.to_string()).collect();
+        let next_keys: Vec<String> = next_keys.unwrap().iter().map(|s| s.to_string()).collect();
+
+        ccount = public_keys.len();
+        rcount = next_keys.len();
+
+        for signer in &ssigners {
+            keys.push(signer.qb64()?);
+            public_keys.push(signer.verfer().qb64()?);
+        }
+
+        (public_keys, next_keys, ssigners)
+    };
+
+    let mut sith = vec![];
+    for _ in 0..ccount {
+        sith.push(dat!("0"));
+    }
+    for _ in 0..scount {
+        sith.push(dat!(&format!("1/{scount}")));
+    }
+    let sith = dat!([dat!(sith.as_slice())]);
+
+    let nsith = if let Some(next_sith) = next_sith {
+        let value: serde_json::Value = serde_json::from_str(next_sith)?;
+        Value::from(&value)
+    } else {
+        let mut nsith = vec![];
+        for _ in 0..rcount {
+            nsith.push(dat!(&format!("1/{rcount}")));
+        }
+        dat!([dat!(nsith.as_slice())])
+    };
+
+    let serder = event::rotate(
+        pre,
+        &public_keys,
+        dig,
+        None,
+        sn,
+        Some(&sith),
+        Some(&ndigs),
+        Some(&nsith),
+        Some(0),
+        None, // Some(&wits),
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+    )?;
+
+    if next_sith.is_some() {
+        return Ok((serder.said()?, ccount, keys, String::from_utf8(serder.raw())?));
+    }
+
+    let mut sigers = vec![];
+    for (index, signer) in signers.iter().enumerate() {
+        let siger = signer.sign_indexed(&serder.raw(), false, index as u32, None)?;
+        sigers.push(siger);
+    }
+
+    let endorsement = endorsement::endorse_serder(Some(&sigers), None, None, None)?;
+    let event = message::messagize_serder(&serder, &endorsement, Some(true))?;
+
+    Ok((serder.said()?, ccount, keys, event))
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn rotate(
+    pre: &str,
+    key_set: &KeySet,
+    dig: &str,
+    sn: u128,
+    sith: Option<&Value>,
+    ncode: Option<&str>,
+    ncount: Option<usize>,
+    nsith: Option<&Value>,
+    wcount: Option<usize>,
+    tier: Option<&str>,
+) -> Result<(String, Vec<String>, String)> {
+    let salter = Salter::new_with_defaults(tier)?;
+    // this can give us the same witnesses as inception
+    // let fixed_salter = Salter::new_with_raw(b"0000000000000000", None, Some(Tierage::low))?;
+
+    #[cfg(not(test))]
+    let temp: Option<bool> = None;
+    #[cfg(test)]
+    let temp: Option<bool> = Some(true);
+
+    let nsigners =
+        salter.signers(ncount, None, Some(&sn.to_string()), ncode, Some(true), None, temp)?;
+
+    let mut result = vec![];
+    let mut digers = vec![];
+    for nsigner in &nsigners {
+        result.push(nsigner.qb64()?);
+        digers.push(Diger::new_with_ser(&nsigner.verfer().qb64b()?, None)?);
+    }
+
+    let mut ndigs = vec![];
+    for diger in &digers {
+        ndigs.push(diger.qb64()?);
+    }
+
+    let mut public_keys = vec![];
+    for verfer in &key_set.verfers()? {
+        public_keys.push(verfer.qb64()?);
+    }
+
+    let wcount = wcount.map(|wcount| wcount as u128);
+    let serder = event::rotate(
+        pre,
+        &public_keys,
+        dig,
+        None,
+        sn,
+        sith,
+        Some(&ndigs),
+        nsith,
+        wcount,
+        None, // Some(&wits),
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+    )?;
+
+    let sigers = key_set.sign(&serder.raw(), Some(&digers))?;
+    let endorsement = endorsement::endorse_serder(Some(&sigers), None, None, None)?;
+    let event = message::messagize_serder(&serder, &endorsement, Some(true))?;
+
+    Ok((serder.said()?, result, event))
+}
+
+pub(crate) fn interact(
+    key_set: &KeySet, // current signing keys
+    pre: &str,        // identifier prefix
+    dig: &str,        // previous event said
+    sn: u128,         // sequence number
+    data: &Value,     // seals
+) -> Result<(String, String)> {
+    let serder = event::interact(pre, dig, Some(sn), Some(data), None, None)?;
+    let sigers = key_set.sign(&serder.raw(), None)?;
+    let endorsement = endorsement::endorse_serder(Some(&sigers), None, None, None)?;
+    let event = message::messagize_serder(&serder, &endorsement, Some(true))?;
+
+    Ok((serder.said()?, event))
+}

--- a/sample/keri/kmi/verification.rs
+++ b/sample/keri/kmi/verification.rs
@@ -1,0 +1,195 @@
+use crate::error::{err, Error, Result};
+
+use cesride::{common::Ilkage, Diger, Indexer, Matter, Prefixer, Sadder, Serder};
+use parside::{message::AttachedMaterialQuadlets, CesrGroup, Group, MessageList};
+
+use super::super::{labels, verification, KeriStore};
+
+use std::collections::HashSet;
+
+pub(crate) fn verify_key_event(
+    store: &impl KeriStore,
+    serder: &Serder,
+    quadlets: &AttachedMaterialQuadlets,
+    deep: Option<bool>,
+    verifying: Option<&mut HashSet<String>>,
+    _indent: usize,
+) -> Result<bool> {
+    let mut backing_set = HashSet::new();
+    let verifying = verifying.unwrap_or(&mut backing_set);
+
+    // println!("{:?}", verifying);
+
+    let pre = serder.pre()?;
+    let ked = serder.ked();
+
+    // see if code is supported
+    let prefixer = Prefixer::new_with_qb64(&pre)?;
+
+    let sn = serder.sn()?;
+    let ilk = ked["t"].to_string()?;
+    let said = serder.said()?;
+
+    let mut existing = false;
+
+    let inceptive = ilk == Ilkage::icp;
+    let key_event_count = store.count_key_events(&pre)?;
+    if inceptive {
+        if !prefixer.verify(&serder.ked(), Some(true))? {
+            return err!(Error::Verification);
+        }
+
+        if sn != 0 {
+            // must be 0
+            return err!(Error::Decoding);
+        }
+
+        if said != serder.pre()? {
+            return err!(Error::Verification);
+        }
+
+        if key_event_count != 0 {
+            existing = true;
+        }
+    } else {
+        if !serder.saider().verify(&serder.ked(), Some(inceptive), Some(true), None, None, None)? {
+            return err!(Error::Verification);
+        }
+
+        if sn < 1 {
+            return err!(Error::Validation);
+        }
+
+        let sno = key_event_count as u128;
+
+        if sn > sno {
+            // escrow here
+            return err!(Error::OutOfOrder);
+        }
+
+        if sn != sno {
+            existing = true;
+        }
+    }
+
+    let (verfers, tholder) = if serder.est()? {
+        let tholder = if let Some(tholder) = serder.tholder()? {
+            tholder
+        } else {
+            return err!(Error::Decoding);
+        };
+
+        (serder.verfers()?, tholder)
+    } else {
+        let (raw, _) = store.get_latest_establishment_event_as_of_sn(&pre, sn as u32 - 1)?;
+        let serder = Serder::new_with_raw(raw.as_bytes())?;
+
+        let tholder = if let Some(tholder) = serder.tholder()? {
+            tholder
+        } else {
+            return err!(Error::Decoding);
+        };
+
+        (serder.verfers()?, tholder)
+    };
+
+    let mut verified_indices = vec![];
+    let mut verified_prior_next_indices = vec![];
+    for group in quadlets.value() {
+        match group {
+            CesrGroup::ControllerIdxSigsVariant { value } => {
+                for controller_idx_sig in value.value() {
+                    let siger = &controller_idx_sig.siger;
+
+                    if siger.index() as usize > verfers.len() {
+                        return err!(Error::Verification);
+                    }
+
+                    if verfers[siger.index() as usize].verify(&siger.raw(), &serder.raw())? {
+                        verified_indices.push(siger.index());
+                        verified_prior_next_indices.push(siger.ondex());
+                    }
+                }
+            }
+            _ => return err!(Error::Decoding),
+        }
+    }
+
+    if !tholder.satisfy(&verified_indices)? {
+        return err!(Error::Verification);
+    }
+
+    let labels = match ilk.as_str() {
+        Ilkage::icp => &labels::ICP_LABELS,
+        Ilkage::rot => &labels::ROT_LABELS,
+        Ilkage::ixn => &labels::IXN_LABELS,
+        _ => return err!(Error::Decoding),
+    };
+    if !verification::verify_ked_labels(&ked, labels)? {
+        return err!(Error::Validation);
+    }
+
+    if !inceptive {
+        // this sn implementation will become a problem at around 4 billion events
+        let event = store.get_key_event(&pre, sn as u32 - 1)?;
+        let pserder = Serder::new_with_raw(event.as_bytes())?;
+        if pserder.said()? != serder.ked()["p"].to_string()? {
+            return err!(Error::Validation);
+        }
+
+        if serder.est()? {
+            let (digers, ntholder) = if pserder.est()? {
+                (pserder.digers()?, pserder.ntholder()?.unwrap_or_default())
+            } else {
+                let (event, _) =
+                    store.get_latest_establishment_event_as_of_sn(&pre, sn as u32 - 1)?;
+                let serder = Serder::new_with_raw(event.as_bytes())?;
+                (serder.digers()?, serder.ntholder()?.unwrap_or_default())
+            };
+
+            let mut prior_next_indices = vec![];
+            for (i, index) in verified_indices.iter().enumerate() {
+                let prior_next_index = verified_prior_next_indices[i];
+                if (prior_next_index as usize) < digers.len() {
+                    let verfer = &verfers[*index as usize];
+                    let diger = Diger::new_with_ser(&verfer.qb64b()?, None)?;
+                    if diger.qb64()? == digers[prior_next_index as usize].qb64()? {
+                        prior_next_indices.push(prior_next_index);
+                    }
+                }
+            }
+
+            if !ntholder.satisfy(&prior_next_indices)? {
+                println!("{prior_next_indices:?}, {verified_indices:?}");
+                return err!(Error::Validation);
+            }
+        }
+
+        if deep.unwrap_or(false) && !verifying.contains(&pserder.said()?) {
+            verifying.insert(pserder.said()?);
+
+            let (_, message_list) =
+                MessageList::from_stream_bytes(event[pserder.raw().len()..].as_bytes())?;
+            let group = message_list.messages[0].cesr_group()?;
+
+            match group {
+                CesrGroup::AttachedMaterialQuadletsVariant { value } => {
+                    verify_key_event(store, &pserder, value, deep, Some(verifying), _indent + 2)?;
+                }
+                _ => return err!(Error::Decoding),
+            }
+        }
+    }
+
+    if existing {
+        let event = store.get_key_event(&pre, sn as u32)?;
+        let eserder = Serder::new_with_raw(event.as_bytes())?;
+
+        // this seems very bad, it means something is in the database that shouldn't be there. how did it get there?
+        if said != eserder.said()? {
+            return err!(Error::Programmer);
+        }
+    }
+
+    Ok(existing)
+}

--- a/sample/keri/labels.rs
+++ b/sample/keri/labels.rs
@@ -1,0 +1,30 @@
+#![allow(unused)]
+
+pub(crate) const ICP_LABELS: &[&str] =
+    &["v", "t", "d", "i", "s", "kt", "k", "nt", "n", "bt", "b", "c", "a"];
+pub(crate) const DIP_LABELS: &[&str] =
+    &["v", "d", "i", "s", "t", "kt", "k", "nt", "n", "bt", "b", "c", "a", "di"];
+pub(crate) const ROT_LABELS: &[&str] =
+    &["v", "d", "i", "s", "t", "p", "kt", "k", "nt", "n", "bt", "br", "ba", "a"];
+pub(crate) const DRT_LABELS: &[&str] =
+    &["v", "d", "i", "s", "t", "p", "kt", "k", "nt", "n", "bt", "br", "ba", "a"];
+
+pub(crate) const IXN_LABELS: &[&str] = &["v", "d", "i", "s", "t", "p", "a"];
+pub(crate) const KSN_LABELS: &[&str] = &[
+    "v", "d", "i", "s", "p", "d", "f", "dt", "et", "kt", "k", "nt", "n", "bt", "b", "c", "ee", "di",
+];
+
+pub(crate) const RPY_LABELS: &[&str] = &["v", "d", "t", "d", "dt", "r", "a"];
+
+pub(crate) const VCP_LABELS: &[&str] = &["v", "d", "i", "s", "t", "bt", "b", "c"];
+pub(crate) const VRT_LABELS: &[&str] = &["v", "d", "i", "s", "t", "p", "bt", "b", "ba", "br"];
+
+pub(crate) const ISS_LABELS: &[&str] = &["v", "i", "s", "t", "ri", "dt"];
+pub(crate) const BIS_LABELS: &[&str] = &["v", "i", "s", "t", "ra", "dt"];
+
+pub(crate) const REV_LABELS: &[&str] = &["v", "i", "s", "t", "p", "dt"];
+pub(crate) const BRV_LABELS: &[&str] = &["v", "i", "s", "t", "ra", "p", "dt"];
+
+pub(crate) const TSN_LABELS: &[&str] =
+    &["v", "i", "s", "d", "ii", "a", "et", "bt", "b", "c", "br", "ba"];
+pub(crate) const CRED_TSN_LABELS: &[&str] = &["v", "i", "s", "d", "ri", "a", "ra"];

--- a/sample/keri/mod.rs
+++ b/sample/keri/mod.rs
@@ -1,0 +1,114 @@
+pub(crate) mod acdc;
+pub(crate) mod kmi;
+pub(crate) mod labels;
+pub(crate) mod parsing;
+pub(crate) mod verification;
+
+use crate::error::{err, Error, Result};
+use cesride::{Diger, Matter, Siger, Signer, Verfer};
+use serde::{Deserialize, Serialize};
+use zeroize::Zeroize;
+
+#[derive(Serialize, Deserialize, Zeroize)]
+pub struct KeySet {
+    pub keys: Vec<String>,
+    pub index_offset: usize,
+    pub transferable: bool,
+}
+
+impl KeySet {
+    pub fn signers(&self) -> Result<Vec<Signer>> {
+        let mut result = vec![];
+        for key in &self.keys {
+            let signer = Signer::new_with_qb64(key, Some(self.transferable))?;
+            result.push(signer);
+        }
+        Ok(result)
+    }
+
+    pub fn verfers(&self) -> Result<Vec<Verfer>> {
+        let mut verfers = vec![];
+
+        for signer in &self.signers()? {
+            verfers.push(signer.verfer());
+        }
+
+        Ok(verfers)
+    }
+
+    // if you pass in digers, this will throw a Validation error if the number of digers matched
+    // is not equal to the number of keys represented by `self`
+    pub fn sign(&self, ser: &[u8], digers: Option<&[Diger]>) -> Result<Vec<Siger>> {
+        let mut sigers = vec![];
+        let mut index = self.index_offset as u32;
+        let mut ondex = None;
+        let mut digers_matched = 0;
+
+        for signer in &self.signers()? {
+            if let Some(digers) = digers {
+                for (i, diger) in digers.iter().enumerate() {
+                    if diger.verify(&signer.verfer().qb64b()?)? {
+                        ondex = Some(i as u32);
+                        digers_matched += 1;
+                        break;
+                    }
+                }
+            }
+
+            let siger = signer.sign_indexed(ser, false, index, ondex)?;
+            sigers.push(siger);
+
+            index += 1;
+            ondex = None;
+        }
+
+        if digers.is_some() && self.keys.len() != digers_matched {
+            return err!(Error::Validation);
+        }
+
+        Ok(sigers)
+    }
+}
+
+pub trait KeriStore {
+    fn prefix(&self) -> String;
+
+    fn insert_keys(
+        &mut self,
+        pre: &str,
+        keys: &[String],
+        index_offset: usize,
+        transferable: bool,
+    ) -> Result<KeySet>;
+    fn insert_sad(&mut self, sad: &str) -> Result<()>;
+    fn insert_acdc(&mut self, acdc: &str) -> Result<()>;
+    fn insert_key_event(&mut self, pre: &str, event: &str) -> Result<()>;
+    fn insert_transaction_event(&mut self, pre: &str, event: &str) -> Result<()>;
+
+    fn get_current_keys(&self, pre: &str) -> Result<KeySet>;
+    fn get_next_keys(&self, pre: &str) -> Result<KeySet>;
+
+    fn get_sad(&self, said: &str) -> Result<String>;
+    fn get_acdc(&self, said: &str) -> Result<String>;
+    fn get_key_event(&self, pre: &str, version: u32) -> Result<String>;
+    fn get_transaction_event(&self, pre: &str, version: u32) -> Result<String>;
+    fn get_latest_establishment_event(&self, pre: &str) -> Result<(String, u128)>;
+    fn get_latest_establishment_event_as_of_sn(&self, pre: &str, sn: u32)
+        -> Result<(String, u128)>;
+    fn get_latest_transaction_event(&self, pre: &str) -> Result<String>;
+
+    fn get_latest_key_event_said(&self, pre: &str) -> Result<String>;
+    fn get_latest_establishment_event_said(&self, pre: &str) -> Result<(String, u128)>;
+    fn get_latest_establishment_event_said_as_of_sn(
+        &self,
+        pre: &str,
+        sn: u32,
+    ) -> Result<(String, u128)>;
+
+    fn get_kel(&self, pre: &str) -> Result<Vec<String>>;
+    fn get_tel(&self, pre: &str) -> Result<Vec<String>>;
+
+    fn count_key_events(&self, pre: &str) -> Result<usize>;
+    fn count_transaction_events(&self, pre: &str) -> Result<usize>;
+    fn count_establishment_events(&self, pre: &str) -> Result<usize>;
+}

--- a/sample/keri/parsing.rs
+++ b/sample/keri/parsing.rs
@@ -1,0 +1,149 @@
+use crate::error::{err, Error, Result};
+
+use cesride::{
+    common::{Identage, Ilkage},
+    Creder, Sadder, Serder,
+};
+use parside::{message::GroupItem, CesrGroup, MessageList};
+
+use super::{acdc, kmi, KeriStore};
+
+use std::collections::HashSet;
+
+fn seen_said(store: &impl KeriStore, said: &str) -> bool {
+    store.get_sad(said).is_ok()
+}
+
+pub fn ingest_messages(
+    store: &mut impl KeriStore,
+    messages: &str,
+    deep: Option<bool>,
+    verify: Option<bool>,
+) -> Result<()> {
+    let mut verifying = HashSet::new();
+
+    let (_, message_list) = MessageList::from_stream_bytes(messages.as_bytes())?;
+    let mut messages = message_list.messages.iter();
+
+    loop {
+        let sadder = messages.next();
+        if let Some(sadder) = sadder {
+            let payload = sadder.payload()?;
+            let raw_string = payload.value.to_string();
+            let raw_message = raw_string.as_bytes();
+            let result = cesride::common::sniff(raw_message)?;
+
+            // println!("{:?}", verifying);
+
+            if result.ident == Identage::KERI {
+                let serder = Serder::new_with_raw(raw_message)?;
+                let said = serder.said()?;
+
+                let message = messages.next();
+                if let Some(message) = message {
+                    let group = message.cesr_group()?;
+                    match serder.ked()["t"].to_string()?.as_str() {
+                        Ilkage::icp | Ilkage::rot | Ilkage::ixn => {
+                            match group {
+                                CesrGroup::AttachedMaterialQuadletsVariant { value } => {
+                                    let existing =
+                                        if verify.unwrap_or(true) && !verifying.contains(&said) {
+                                            verifying.insert(said);
+                                            kmi::verification::verify_key_event(
+                                                store,
+                                                &serder,
+                                                value,
+                                                deep,
+                                                Some(&mut verifying),
+                                                0,
+                                            )?
+                                        } else {
+                                            seen_said(store, &said)
+                                        };
+
+                                    if !existing {
+                                        let event = String::from_utf8(serder.raw())?;
+                                        store.insert_key_event(
+                                            &serder.pre()?,
+                                            &(event + &group.qb64()?),
+                                        )?;
+                                    }
+                                }
+                                _ => return err!(Error::Decoding), // we only accept pipelined input at present
+                            }
+                        }
+                        Ilkage::vcp | Ilkage::iss | Ilkage::rev => match group {
+                            CesrGroup::SealSourceCouplesVariant { value } => {
+                                let existing =
+                                    if verify.unwrap_or(true) && !verifying.contains(&said) {
+                                        verifying.insert(said);
+                                        acdc::tel::verification::verify_transaction_event(
+                                            store,
+                                            &serder,
+                                            value,
+                                            deep,
+                                            Some(&mut verifying),
+                                            0,
+                                        )?
+                                    } else {
+                                        seen_said(store, &said)
+                                    };
+
+                                if !existing {
+                                    let event = String::from_utf8(serder.raw())?;
+                                    store.insert_transaction_event(
+                                        &serder.pre()?,
+                                        &(event + &group.qb64()?),
+                                    )?;
+                                }
+                            }
+                            _ => return err!(Error::Decoding),
+                        },
+                        _ => return err!(Error::Decoding),
+                    }
+                } else {
+                    return err!(Error::Decoding);
+                }
+            } else if result.ident == Identage::ACDC {
+                let creder = Creder::new_with_raw(raw_message)?;
+                let said = creder.said()?;
+
+                let message = messages.next();
+                if let Some(message) = message {
+                    let group = message.cesr_group()?;
+                    match group {
+                        CesrGroup::AttachedMaterialQuadletsVariant { value } => {
+                            let existing = if verify.unwrap_or(true) && !verifying.contains(&said) {
+                                verifying.insert(said);
+                                acdc::verification::verify_acdc(
+                                    store,
+                                    &creder,
+                                    value,
+                                    deep,
+                                    Some(&mut verifying),
+                                    0,
+                                )?
+                            } else {
+                                seen_said(store, &said)
+                            };
+
+                            if !existing {
+                                let acdc = String::from_utf8(creder.raw())?;
+                                store.insert_acdc(&(acdc + &group.qb64()?))?;
+                            }
+                        }
+                        _ => return err!(Error::Decoding), // we only accept pipelined input at present
+                    };
+                } else {
+                    return err!(Error::Decoding);
+                }
+            } else {
+                return err!(Error::Decoding);
+            }
+        } else {
+            break;
+        }
+    }
+
+    Ok(())
+}

--- a/sample/keri/verification.rs
+++ b/sample/keri/verification.rs
@@ -1,0 +1,86 @@
+use super::{kmi, KeriStore};
+use crate::error::{err, Error, Result};
+
+use cesride::{common::Ilkage, data::Value, Matter, Sadder, Saider, Seqner, Serder};
+use parside::{CesrGroup, MessageList};
+
+use std::collections::HashSet;
+
+pub(crate) fn extract_registry_from_serder(ilk: &str, serder: &Serder) -> Result<String> {
+    match ilk {
+        Ilkage::vcp => serder.pre(),
+        Ilkage::iss | Ilkage::rev => serder.ked()["ri"].to_string(),
+        _ => err!(Error::Decoding),
+    }
+}
+
+pub(crate) fn verify_ked_labels(ked: &Value, labels: &[&str]) -> Result<bool> {
+    let map = ked.to_map()?;
+    for label in labels {
+        if !map.contains_key(&label.to_string()) {
+            return Ok(false);
+        }
+    }
+
+    Ok(true)
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn verify_anchor(
+    store: &impl KeriStore,
+    anchor_pre: &str,
+    seqner: &Seqner,
+    saider: &Saider,
+    serder: &Serder,
+    deep: Option<bool>,
+    verifying: Option<&mut HashSet<String>>,
+    _indent: usize,
+) -> Result<bool> {
+    let mut backing_set = HashSet::new();
+    let verifying = verifying.unwrap_or(&mut backing_set);
+
+    let event = store.get_key_event(anchor_pre, seqner.sn()? as u32)?;
+    let aserder = Serder::new_with_raw(event.as_bytes())?;
+    if aserder.said()? != saider.qb64()? {
+        return Ok(false);
+    }
+
+    let seals = aserder.ked()["a"].to_vec()?;
+    if seals.len() != 1 {
+        return Ok(false);
+    }
+
+    let seal = &seals[0];
+
+    let spre = seal["i"].to_string()?;
+    let ssn = seal["s"].to_string()?;
+    let sdig = seal["d"].to_string()?;
+
+    if deep.unwrap_or(false) && !verifying.contains(&aserder.said()?) {
+        verifying.insert(aserder.said()?);
+
+        let (_, message_list) =
+            MessageList::from_stream_bytes(event[aserder.raw().len()..].as_bytes())?;
+        let group = message_list.messages[0].cesr_group()?;
+
+        match group {
+            CesrGroup::AttachedMaterialQuadletsVariant { value } => {
+                kmi::verification::verify_key_event(
+                    store,
+                    &aserder,
+                    value,
+                    deep,
+                    Some(verifying),
+                    _indent,
+                )?;
+            }
+            _ => return err!(Error::Decoding),
+        }
+    }
+
+    if ssn == serder.ked()["s"].to_string()? && spre == serder.pre()? && sdig == serder.said()? {
+        return Ok(true);
+    }
+
+    Ok(false)
+}


### PR DESCRIPTION
thought this might be useful. some of it isn't that generic but it's a good start.

to note:
- i played fast and loose with errors as they didn't matter to me at the time, verifications could probably better be labelled validation and vice versa
- some things can probably be named better
- verifications may not be complete
- tel stuff is hardcoded to use no backers
- the verification code has `_indent` passed around as a variable, it should likely be removed. i was using it for debugging
- you'll need to implement a KeriStore (the trait is defined here) to use some of the code
- really more things should probably be structs and not strings. for example, it would be nice if the KeySet (actually a Vec) actually established a security boundary around the keys, generating and signing from within its own implementation, so that the keys are transformed as few times as possible and seen by less code